### PR TITLE
Add support for the old `GameController`

### DIFF
--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -7,7 +7,7 @@ use std::{
 use color_eyre::Result;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 use serialize_hierarchy::{Error, SerializeHierarchy};
-use spl_network_messages::{Penalty, PlayerNumber, TeamState};
+use spl_network_messages::{Penalty, Player, PlayerNumber, TeamState};
 
 #[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
 pub struct Players<T> {
@@ -50,16 +50,30 @@ impl<T> IndexMut<PlayerNumber> for Players<T> {
     }
 }
 
+trait PlayerPenalty {
+    fn get_penalty(&self, player_index: usize) -> Penalty;
+}
+
+impl PlayerPenalty for Vec<Player> {
+    fn get_penalty(&self, player_index: usize) -> Penalty {
+        if self.len() > player_index {
+            self[player_index].penalty
+        } else {
+            Penalty::None
+        }
+    }
+}
+
 impl From<TeamState> for Players<Penalty> {
     fn from(team_state: TeamState) -> Self {
         Self {
-            one: team_state.players[0].penalty,
-            two: team_state.players[1].penalty,
-            three: team_state.players[2].penalty,
-            four: team_state.players[3].penalty,
-            five: team_state.players[4].penalty,
-            six: team_state.players[5].penalty,
-            seven: team_state.players[6].penalty,
+            one: team_state.players.get_penalty(0),
+            two: team_state.players.get_penalty(1),
+            three: team_state.players.get_penalty(2),
+            four: team_state.players.get_penalty(3),
+            five: team_state.players.get_penalty(4),
+            six: team_state.players.get_penalty(5),
+            seven: team_state.players.get_penalty(6),
         }
     }
 }


### PR DESCRIPTION
## Introduced Changes

Check if array indexing is within bounds when reading the penalty for a player.

Fixes #20 

## How to Test
Use the [java GameController](https://github.com/RoboCup-SPL/GameController) with the latest version.
### Tested on 23-04-2023
Tested player numbers: 4, 5, 6(when subbed in) and 7(lol).
All of these player numbers worked fine with this change.

