### PR TITLE
Implement dutch flag eyes in Unstiff

### DIFF
--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -264,8 +264,8 @@ impl LedStatus {
         }
     }
 
-    pub fn intensity_to_dnt_color(location:i32, intensity: f32) -> Rgb {
-        let intensity =  (255.0 * intensity) as u8;
+    pub fn intensity_to_dnt_color(location: i32, intensity: f32) -> Rgb {
+        let intensity = (255.0 * intensity) as u8;
         match location {
             0 | 7 | 1 => Rgb::new(intensity, 0, 0),
             2 | 6 => Rgb::new(intensity, intensity, intensity),


### PR DESCRIPTION
## Introduced Changes

switched out functions to get different eye colors
#40 

## Ideas for Next Iterations (Not This PR)

We can improve this by setting a bound to the lowest intensity, since the intensity of 0 is greyish and ugly

## How to Test
When in unstiff, the eyes should be the dutch flag with a varying intensity.
